### PR TITLE
Add FT System code to all preview apps

### DIFF
--- a/app.json
+++ b/app.json
@@ -30,6 +30,9 @@
     },
     "GOOGLE_SERVICE_KEY": {
       "required": true
+    },
+    "SYSTEM_CODE": {
+      "value": "bertha"    
     }
   },
   "image": "heroku/nodejs",


### PR DESCRIPTION
Biz Ops wants all Heroku Apps to have a SYSTEM_CODE environment variable. This will ensure it's added to all preview apps when they're created.