### PR TITLE
Add rate limiting

### DIFF
--- a/lib/web/app.js
+++ b/lib/web/app.js
@@ -7,6 +7,7 @@ var Message = require('../message.js'),
 	view = require('./view.js'),
 	purge = require('./purge.js');
 
+const { rateLimit, defaultRateLimitOptions } = require('./rate-limit.js')
 
 var defaultOptions = {
 	port: process.env.PORT || 3000,
@@ -62,14 +63,35 @@ exports.create = function create( options, callback ) {
 	app.set( 'port', options.port );
 	app.set( 'queueRegistry', queueRegistry );
 
-	app.get('/', rootHandler)
+	app.get('/', rateLimit({
+		...defaultRateLimitOptions,
+		ruleName: 'root',
+		windowMs: 1000 * 60 * 5,
+		max: 100,
+		skipSuccessfulRequests: true,
+	}), rootHandler)
 	
 	app.get( '/robots.txt', function (req, res) {
 		res.type('text/plain')
 		res.send("User-agent: *\nDisallow: /");
 	});
 
+	app.get('/view/*', rateLimit({
+		...defaultRateLimitOptions,
+		ruleName: 'view',
+		skipSuccessfulRequests: true,
+		windowMs: 1000 * 60 * 15,
+		max: 100,
+	}))
+
 	app.get('/trace-headers', traceHeaders)
+	app.get('/trace-rate-limit', rateLimit({
+		...defaultRateLimitOptions,
+		ruleName: 'trace',
+		windowMs: 2000,
+		max: 1,		
+	}), traceRateLimit)
+
 	app.get( '/short/:queue/:plugin/:key', setExpiry('short') );
 	app.get( '/short/:queue/:plugin/:key/:sheet', setExpiry('short') );
 	app.get( '/long/:queue/:plugin/:key', setExpiry('forever') );
@@ -94,7 +116,14 @@ exports.create = function create( options, callback ) {
 	app.get( options.docPath + '/:queue/:plugin/:key', view.respond() );
 	app.get( options.docPath + '/:queue/:plugin/:key/:sheet', view.respond() );
 
-	app.get(/^\/(republish|purge)\/.*/, purge.headers());
+	const republishRateLimit = rateLimit({
+		...defaultRateLimitOptions,
+		ruleName: 'republish',
+		windowMs: 1000 * 30,
+		max: 30,
+	})
+
+	app.get(/^\/(republish|purge)\/.*/, republishRateLimit, purge.headers());
 
 	app.get('/purge/:queue/:plugin/:key', purge.purge() );
 	app.get('/purge/:queue/:plugin/:key/:sheet', purge.purge() );
@@ -288,4 +317,11 @@ function traceHeaders(req, res) {
 		h: req.headers
 	})
 	return notFound(res)
+}
+
+function traceRateLimit(req, res) {
+	if (req.query.d === 'error') {
+		return badRequest(res)
+	}
+	res.send('Not rate limited')
 }

--- a/lib/web/rate-limit.js
+++ b/lib/web/rate-limit.js
@@ -1,0 +1,91 @@
+const expressRateLimit = require('express-rate-limit')
+
+const validModes = new Set(['silent', 'report', 'error'])
+
+const mode = (
+    process.env.RATE_LIMIT && validModes.has(process.env.RATE_LIMIT)
+    ? process.env.RATE_LIMIT
+    : undefined
+)
+
+// rateLimit middleware is a noop unless process.env.RATE_LIMIT
+// has a valid value
+const rateLimit = mode ? expressRateLimit : noopMiddleware
+
+console.log(`Rate limiting is ${
+    mode ? `enabled in ${mode} mode` : 'disabled'
+}`)
+
+const defaultRateLimitOptions = {
+	message: 'Rate limited',
+	draft_polli_ratelimit_headers: true,
+	mode,
+	ruleName: 'default',
+	keyGenerator,
+	handler,
+}
+
+function handler (req, res, next, options) {
+    logRequest(req, options)
+
+    if (options.mode === 'error') {
+        res.status(options.statusCode).send(options.message).end();
+    } else {
+        next();
+    }
+}
+
+function getIpAddress(req) {
+    return req.get('fastly-client-ip') || req.ip
+} 
+
+function keyGenerator (req) {
+    return getIpAddress(req)
+}
+
+function noopMiddleware () {
+    return (_req, _res, next) => {
+        next()
+    }
+}
+
+function logRequest (req, options) {
+    if (!options.mode || options.mode === 'silent') {
+        return
+    }
+
+    const data = {
+        event: 'RATE_LIMIT',
+        mode: options.mode,
+        ip: getIpAddress(req),
+        ips: req.ips,
+        path: req.path,
+        rule: options.ruleName,
+        request_id: req.requestId,
+        ja3_fingerprint: req.get('ja3-fingerprint'),
+        user_agent: req.get('user-agent'),
+        sec_fetch_site: req.get('Sec-Fetch-Site'),
+    }
+
+    console.log(
+        Object.entries(data)
+            .map(([k, v]) => `${k}="${printValue(v)}"`)
+            .join(' ')
+    )
+}
+
+function printValue (value) {
+    if (Array.isArray(value)) {
+        return value.map(printValue).join(', ')
+    }
+    if (typeof value !== 'string') {
+        return ''
+    }
+    // escape values
+    return value.replace(/"/gm, '\"')
+}
+
+module.exports = {
+    rateLimit,
+    defaultRateLimitOptions,
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "d3": "^3.5.17",
         "d3-dsv": "^3.0.1",
         "express": "^3.21.2",
+        "express-rate-limit": "^5.5.1",
         "google-oauth-jwt": "^0.1.7",
         "js-yaml": "^3.14.1",
         "lodash": "^4.17.21",
@@ -1278,6 +1279,11 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-5.5.1.tgz",
+      "integrity": "sha512-MTjE2eIbHv5DyfuFz4zLYWxpqVhEhkTiwFGuB74Q9CSou2WHO52nlE5y3Zlg6SIsiYUIPj6ifFxnkPz6O3sIUg=="
     },
     "node_modules/express-session": {
       "version": "1.11.3",
@@ -4594,6 +4600,11 @@
           "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
         }
       }
+    },
+    "express-rate-limit": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-5.5.1.tgz",
+      "integrity": "sha512-MTjE2eIbHv5DyfuFz4zLYWxpqVhEhkTiwFGuB74Q9CSou2WHO52nlE5y3Zlg6SIsiYUIPj6ifFxnkPz6O3sIUg=="
     },
     "express-session": {
       "version": "1.11.3",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "d3": "^3.5.17",
     "d3-dsv": "^3.0.1",
     "express": "^3.21.2",
+    "express-rate-limit": "^5.5.1",
     "google-oauth-jwt": "^0.1.7",
     "js-yaml": "^3.14.1",
     "lodash": "^4.17.21",


### PR DESCRIPTION
Defines different limits for the various paths.

Only uses an in memory rate counter at the moment. This is easy to circumvent but it's fast and simple enough to provide some protection.

It also provides 3 modes: silent, report and error. This allows us to change the behaviour without a code change. It allows us to log and not send an error to the client. This helps us observe and analyse the traffic, spotting false positives, before actually blocking clients.